### PR TITLE
feat: add keyword, unit, and subject domain entities

### DIFF
--- a/cmd/keyword/main.go
+++ b/cmd/keyword/main.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/ericvignolajr/bingo-keyword-service
+
+go 1.19
+
+require github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/pkg/domain/keyword.go
+++ b/pkg/domain/keyword.go
@@ -1,0 +1,20 @@
+package domain
+
+import (
+	"image"
+	_ "image/jpeg"
+	_ "image/png"
+
+	"github.com/google/uuid"
+)
+
+type Keyword struct {
+	Id               uuid.UUID
+	Name, Definition string
+	Picture          image.Image
+	TranslateTo      map[string]Translation
+}
+
+type Translation struct {
+	Name, Definition string
+}

--- a/pkg/domain/subject.go
+++ b/pkg/domain/subject.go
@@ -1,0 +1,9 @@
+package domain
+
+import "github.com/google/uuid"
+
+type Subject struct {
+	Id    uuid.UUID
+	Name  string
+	Units []*Unit
+}

--- a/pkg/domain/unit.go
+++ b/pkg/domain/unit.go
@@ -1,0 +1,10 @@
+package domain
+
+import "github.com/google/uuid"
+
+type Unit struct {
+	Id          uuid.UUID
+	Name        string
+	Keywords    []*Keyword
+	TranslateTo map[string]string
+}


### PR DESCRIPTION
Add domain entities for a keyword, unit, and subject. Keyword is the smallest unit, unit is a collection of keywords, and subject is a collection of units. This is the beginning of the domain and the innermost core of the business rules.