### PR TITLE
refactor: add map to user model

### DIFF
--- a/pkg/domain/user_test.go
+++ b/pkg/domain/user_test.go
@@ -94,11 +94,19 @@ func TestFindSubject(t *testing.T) {
 	}
 
 	subject, _ := NewSubject("science", user.ID)
-	user.AddSubject(*subject)
+	_, err = user.AddSubject(*subject)
+	if err != nil {
+		t.Error(err)
+	}
 
-	actual, _ := user.FindSubject(subject.ID)
+	actual, err := user.FindSubject(subject.ID)
+	if err != nil {
+		t.Error(err)
+	}
 
-	assert.Equal(t, subject, actual)
+	if isEqual := cmp.Equal(subject, actual); isEqual != true {
+		t.Errorf("%s\n", cmp.Diff(subject, actual))
+	}
 }
 
 func TestEqual(t *testing.T) {
@@ -150,4 +158,41 @@ func TestEqual(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDeleteSubject(t *testing.T) {
+	u, err := NewUser("foo@example.com", "fake pass")
+	if err != nil {
+		t.Error(err)
+	}
+
+	s1, err := NewSubject("science", u.ID)
+	if err != nil {
+		t.Error(err)
+	}
+	s2, err := NewSubject("math", u.ID)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = u.AddSubject(*s1)
+	if err != nil {
+		t.Error(err)
+	}
+	_, err = u.AddSubject(*s2)
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = u.DeleteSubject(s1.ID)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.NotContains(t, u.Subjects, s1)
+	_, ok := u.subjectsMap[s1.ID]
+	if ok {
+		t.Errorf("the key %s for subject %s should have been removed from the user's subjects map, but the key is still present", s1.ID, s1.Name)
+	}
+
 }

--- a/pkg/usecases/readSubjects.go
+++ b/pkg/usecases/readSubjects.go
@@ -18,18 +18,15 @@ func (r *ReadSubjects) Exec(userID uuid.UUID, subjectID *uuid.UUID) ([]domain.Su
 	user, err := r.UserStore.ReadById(userID)
 	if err != nil {
 		return nil, fmt.Errorf("in readSubjects: %w", err)
-		return nil, fmt.Errorf("in readSubjects: %w", err)
 	}
 
 	subjectOutput := make([]domain.Subject, 0, len(user.Subjects))
 	if subjectID != nil {
-		for _, v := range user.Subjects {
-			if v.ID == *subjectID {
-				// there should only be one subject with id matching subjectID
-				subjectOutput = append(subjectOutput, *v)
-				break
-			}
+		s, err := user.FindSubject(*subjectID)
+		if err != nil {
+			return nil, fmt.Errorf("in readSubjects: %w", err)
 		}
+		subjectOutput = append(subjectOutput, *s)
 	} else {
 		for _, v := range user.Subjects {
 			subjectOutput = append(subjectOutput, *v)
@@ -40,6 +37,5 @@ func (r *ReadSubjects) Exec(userID uuid.UUID, subjectID *uuid.UUID) ([]domain.Su
 		return strings.ToLower(subjectOutput[i].Name) < strings.ToLower(subjectOutput[j].Name)
 	})
 
-	return subjectOutput, nil
 	return subjectOutput, nil
 }

--- a/pkg/usecases/readSubjects_test.go
+++ b/pkg/usecases/readSubjects_test.go
@@ -10,6 +10,46 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestReadSubjectByID(t *testing.T) {
+	userStore := inmemory.UserStore{}
+	uid, err := userStore.Create("foobar@example.com", "supersecret")
+	if err != nil {
+		panic(err)
+	}
+	user, err := userStore.ReadById(uid)
+	if err != nil {
+		t.Error(err)
+	}
+
+	s1, err := domain.NewSubject("Math", uid)
+	if err != nil {
+		panic(err)
+	}
+
+	s2, err := domain.NewSubject("Science", uid)
+	if err != nil {
+		panic(err)
+	}
+
+	user.AddSubject(*s1)
+	user.AddSubject(*s2)
+
+	readSubjects := usecases.ReadSubjects{
+		UserStore: &userStore,
+	}
+
+	res, err := readSubjects.Exec(uid, &s1.ID)
+	if err != nil {
+		t.Error(err)
+	}
+
+	isEqual := cmp.Equal(*s1, res[0])
+	if isEqual != true {
+		diff := cmp.Diff(*s1, res[0])
+		t.Errorf("\non TestReadSubjects %v", diff)
+	}
+}
+
 func TestReadSubjects(t *testing.T) {
 	userStore := inmemory.UserStore{}
 	uid, err := userStore.Create("foobar@example.com", "supersecret")


### PR DESCRIPTION
Add map to user model to make accessing a single subject by id faster instead of iterating the entire subjects slice.