### PR TITLE
refactor: add not found error to stores package and update user equal function

### DIFF
--- a/pkg/delivery/rest/main.go
+++ b/pkg/delivery/rest/main.go
@@ -37,27 +37,27 @@ func NewServer() chi.Router {
 	subjectStore := inmemory.NewSubjectStore()
 
 	createSubject := usecases.CreateSubject{
-		UserStore:    &sessions.UserStore,
+		UserStore:    sessions.UserStore,
 		SubjectStore: subjectStore,
 	}
 
 	readSubject := usecases.ReadSubjectByID{
-		UserStore:    &sessions.UserStore,
+		UserStore:    sessions.UserStore,
 		SubjectStore: subjectStore,
 	}
 
 	readSubjects := usecases.ReadSubjects{
-		UserStore: &sessions.UserStore,
+		UserStore: sessions.UserStore,
 	}
 
 	deleteSubject := usecases.DeleteSubject{
 		SubjectStore: subjectStore,
-		UserStore:    &sessions.UserStore,
+		UserStore:    sessions.UserStore,
 	}
 
 	createUnit := usecases.CreateUnit{
 		SubjectStore: subjectStore,
-		UserStore:    &sessions.UserStore,
+		UserStore:    sessions.UserStore,
 	}
 
 	r.Get("/", func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/domain/user.go
+++ b/pkg/domain/user.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 )
 
 const (
@@ -105,9 +106,13 @@ func (u *User) IsDuplicateSubject(s Subject) bool {
 }
 
 func (u *User) Equal(other *User) bool {
-	if other == nil {
+	if u == nil || other == nil {
+		if u == nil && other == nil {
+			return true
+		}
 		return false
 	}
+
 	if u.ID != other.ID {
 		return false
 	}
@@ -123,4 +128,16 @@ func (u *User) Equal(other *User) bool {
 		}
 	}
 	return true
+}
+
+func (u *User) AfterFind(tx *gorm.DB) error {
+	if u.subjectsMap == nil {
+		u.subjectsMap = make(map[uuid.UUID]int)
+	}
+
+	for i, v := range u.Subjects {
+		u.subjectsMap[v.ID] = i
+	}
+
+	return nil
 }

--- a/pkg/stores/errors.go
+++ b/pkg/stores/errors.go
@@ -1,0 +1,9 @@
+package stores
+
+type RecordNotFoundError struct {
+	Err error
+}
+
+func (rnf *RecordNotFoundError) Error() string {
+	return rnf.Err.Error()
+}


### PR DESCRIPTION
The stores packages now returns a custom error type when records are not found so callers can check for this error and handle it accordingly. The User domain model's Equal function was refactored to handle nil instances. 