### PR TITLE
refactor: addUnit now takes pointer and returns nothing

### DIFF
--- a/pkg/domain/subject.go
+++ b/pkg/domain/subject.go
@@ -34,20 +34,20 @@ func NewSubject(name string, ownerID uuid.UUID) (*Subject, error) {
 	}, nil
 }
 
-func (s *Subject) AddUnit(u Unit) (*Unit, error) {
-	isDuplicate := s.IsDuplicateUnit(u)
+func (s *Subject) AddUnit(u *Unit) error {
+	isDuplicate := s.IsDuplicateUnit(*u)
 	if isDuplicate {
-		return nil, fmt.Errorf("%w, subject %s already contains unit %s", ErrDuplicateUnit, s.Name, u.Name)
+		return fmt.Errorf("%w, subject %s already contains unit %s", ErrDuplicateUnit, s.Name, u.Name)
 	}
 
 	capitalizedName := strings.ToUpper(string(u.Name[0])) + u.Name[1:]
 	u.Name = capitalizedName
 
-	s.Units = append(s.Units, &u)
+	s.Units = append(s.Units, u)
 	sort.SliceStable(s.Units, func(i, j int) bool {
 		return strings.ToLower(s.Units[i].Name) < strings.ToLower(s.Units[j].Name)
 	})
-	return &u, nil
+	return nil
 }
 
 func (s *Subject) IsDuplicateUnit(u Unit) bool {

--- a/pkg/domain/subject_test.go
+++ b/pkg/domain/subject_test.go
@@ -40,12 +40,12 @@ func TestAddUnit(t *testing.T) {
 		t.Error(err)
 	}
 
-	newU, err := s.AddUnit(*u)
+	err = s.AddUnit(u)
 	if err != nil {
 		t.Error(err)
 	}
 
-	assert.Equal(t, u, newU)
+	assert.Contains(t, s.Units, u)
 
 }
 
@@ -63,7 +63,7 @@ func TestIsDuplicateUnit(t *testing.T) {
 		t.Error(err)
 	}
 
-	u2, err = s.AddUnit(*u1)
+	err = s.AddUnit(u1)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/stores/sql/subject_test.go
+++ b/pkg/stores/sql/subject_test.go
@@ -17,13 +17,13 @@ func TestDeleteSubject(t *testing.T) {
 	unit.SubjectID = subject.ID
 	keyword, _ := domain.NewKeyword("tesla coil", "a tesla coil")
 	unit.AddKeyword(*keyword)
-	subject.AddUnit(*unit)
+	subject.AddUnit(unit)
 
 	unit2, _ := domain.NewUnit("geology")
 	unit2.SubjectID = subject.ID
 	keyword2, _ := domain.NewKeyword("rock", "a rock")
 	unit2.AddKeyword(*keyword2)
-	subject.AddUnit(*unit2)
+	subject.AddUnit(unit2)
 
 	user.AddSubject(subject)
 

--- a/pkg/stores/sql/user_test.go
+++ b/pkg/stores/sql/user_test.go
@@ -22,7 +22,7 @@ func TestReadById(t *testing.T) {
 	user, _ := domain.NewUser("foo@example.com", "foobar")
 	subj, _ := domain.NewSubject("science", user.ID)
 	unit, _ := domain.NewUnit("electro-magnets")
-	subj.AddUnit(*unit)
+	subj.AddUnit(unit)
 	user.AddSubject(subj)
 	uStore.DB.Create(user)
 

--- a/pkg/usecases/createUnit.go
+++ b/pkg/usecases/createUnit.go
@@ -29,7 +29,7 @@ func (c *CreateUnit) Exec(name string, userID uuid.UUID, subjectID uuid.UUID) (*
 		return nil, fmt.Errorf("in createUnit: %w", err)
 	}
 
-	_, err = s.AddUnit(*u)
+	err = s.AddUnit(u)
 	if err != nil {
 		return nil, fmt.Errorf("in createUnit: %w", err)
 	}


### PR DESCRIPTION
Subject.AddUnit now takes a pointer and returns nothing. This should clarify that this function does not create new entities and only associates existing entities.