### PR TITLE
refactor: addKeyword now takes pointer and returns nothing.

### DIFF
--- a/pkg/domain/unit.go
+++ b/pkg/domain/unit.go
@@ -1,12 +1,15 @@
 package domain
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
+
+var ErrDuplicateKeyword = errors.New("keywords must be unique within a unit")
 
 type Unit struct {
 	gorm.Model
@@ -26,14 +29,14 @@ func NewUnit(name string) (*Unit, error) {
 	}, nil
 }
 
-func (u *Unit) AddKeyword(k Keyword) (*Keyword, error) {
-	isDuplicate := u.IsDuplicateKeyword(k)
+func (u *Unit) AddKeyword(k *Keyword) error {
+	isDuplicate := u.IsDuplicateKeyword(*k)
 	if isDuplicate {
-		return nil, fmt.Errorf("unit %s already contains keyword %s", u.Name, k.Name)
+		return fmt.Errorf("unit %s already contains keyword %s, %w", u.Name, k.Name, ErrDuplicateKeyword)
 	}
 
-	u.Keywords = append(u.Keywords, &k)
-	return &k, nil
+	u.Keywords = append(u.Keywords, k)
+	return nil
 }
 
 func (u *Unit) FindKeyword(keywordID uuid.UUID) (*Keyword, error) {

--- a/pkg/domain/unit_test.go
+++ b/pkg/domain/unit_test.go
@@ -1,6 +1,7 @@
 package domain_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -33,7 +34,7 @@ func TestAddKeyword(t *testing.T) {
 	}
 
 	k1, _ := domain.NewKeyword("magnets", "defintion of a magnet")
-	_, err = u.AddKeyword(*k1)
+	err = u.AddKeyword(k1)
 	if err != nil {
 		t.Errorf("unexpected input when adding keyword to unit %s", err)
 	}
@@ -50,12 +51,12 @@ func TestAddKeyword_DuplicateKeyword(t *testing.T) {
 	k1, _ := domain.NewKeyword("magnets", "defintion of a magnet")
 	k2, _ := domain.NewKeyword("magnets", "defintion of a magnet")
 
-	_, err = u.AddKeyword(*k1)
+	err = u.AddKeyword(k1)
 	if err != nil {
 		t.Errorf("unexpected input when adding keyword to unit %s", err)
 	}
-	_, err = u.AddKeyword(*k2)
-	assert.EqualError(t, err, fmt.Sprintf("unit %s already contains keyword %s", u.Name, k2.Name))
+	err = u.AddKeyword(k2)
+	assert.Equal(t, true, errors.Is(err, domain.ErrDuplicateKeyword))
 
 }
 
@@ -67,7 +68,7 @@ func TestIsDuplicateKeyword(t *testing.T) {
 		t.Errorf("unexpected input when adding keyword to unit %s", err)
 	}
 
-	_, err = u.AddKeyword(*k1)
+	err = u.AddKeyword(k1)
 	if err != nil {
 		t.Errorf("unexpected input when adding keyword to unit %s", err)
 	}

--- a/pkg/stores/sql/subject_test.go
+++ b/pkg/stores/sql/subject_test.go
@@ -16,13 +16,13 @@ func TestDeleteSubject(t *testing.T) {
 	unit, _ := domain.NewUnit("electro magnets")
 	unit.SubjectID = subject.ID
 	keyword, _ := domain.NewKeyword("tesla coil", "a tesla coil")
-	unit.AddKeyword(*keyword)
+	unit.AddKeyword(keyword)
 	subject.AddUnit(unit)
 
 	unit2, _ := domain.NewUnit("geology")
 	unit2.SubjectID = subject.ID
 	keyword2, _ := domain.NewKeyword("rock", "a rock")
-	unit2.AddKeyword(*keyword2)
+	unit2.AddKeyword(keyword2)
 	subject.AddUnit(unit2)
 
 	user.AddSubject(subject)

--- a/pkg/usecases/readSubjects_test.go
+++ b/pkg/usecases/readSubjects_test.go
@@ -82,10 +82,6 @@ func TestReadSubjects(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	res, err = readSubjects.Exec(uid, nil)
-	if err != nil {
-		t.Error(err)
-	}
 
 	expected := []domain.Subject{
 		{ID: s1.ID, Name: s1.Name, UserID: uid},


### PR DESCRIPTION
Unit.AddKeyword now takes a pointer and returns nothing. This should clarify that this function does not create new entities and only associates existing entities.