### PR TITLE
refactor: move user http handlers to their own file

### DIFF
--- a/pkg/delivery/rest/unitHandlers.go
+++ b/pkg/delivery/rest/unitHandlers.go
@@ -37,7 +37,7 @@ func newCreateUnitFormHandler(viewsPath string) http.HandlerFunc {
 	}
 }
 
-func newCreateUnitHandler(createUnitUsecase usecases.CreateUnit, readSubjectUsecase usecases.ReadSubjectByID, viewsPath string) http.HandlerFunc {
+func newCreateUnitHandler(createUnitUsecase usecases.CreateUnit, readSubjectUsecase usecases.ReadSubjectByID) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		u, ok := ctx.Value(sessions.User).(*domain.User)

--- a/pkg/delivery/rest/userHandlers.go
+++ b/pkg/delivery/rest/userHandlers.go
@@ -1,0 +1,47 @@
+package rest
+
+import (
+	"fmt"
+	"html/template"
+	"net/http"
+
+	"github.com/ericvignolajr/bingo-keyword-service/pkg/domain"
+	"github.com/ericvignolajr/bingo-keyword-service/pkg/sessions"
+	"github.com/ericvignolajr/bingo-keyword-service/pkg/usecases"
+)
+
+func newShowHomePageHandler(readSubjectsUsecase usecases.ReadSubjects, viewsPath string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		u, ok := ctx.Value(sessions.User).(*domain.User)
+		if !ok {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte("Unauthorized"))
+			fmt.Println("No user on context")
+			return
+		}
+
+		subjects, err := readSubjectsUsecase.Exec(u.ID, nil)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		data := struct {
+			User     domain.User
+			Subjects []domain.Subject
+		}{
+			User:     *u,
+			Subjects: subjects,
+		}
+
+		res, err := template.ParseFiles(viewsPath+"/base.tmpl", viewsPath+"/user.tmpl")
+		if err != nil {
+			fmt.Println(err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		res.Execute(w, data)
+	}
+}


### PR DESCRIPTION
Move user handlers to their own file for consistent code organization for handlers and to make the http server routes file easier to read